### PR TITLE
Add envsetup script and update build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CC=x86_64-elf-gcc
-AS=x86_64-elf-as
-LD=x86_64-elf-ld
-OBJCOPY=objcopy
+CC ?= x86_64-elf-gcc
+AS ?= x86_64-elf-as
+LD ?= x86_64-elf-ld
+OBJCOPY ?= x86_64-elf-objcopy
 CFLAGS=-ffreestanding -m64 -nostdlib -nostdinc -fno-pic -mno-red-zone -c
 ASFLAGS=--64
 LDFLAGS=-T linker.ld -nostdlib

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repository contains a minimal x86_64 hobby kernel.
 
 ## Building
 
-Ensure the cross toolchain is available in your `PATH`:
+Before building, source the environment setup script to add the cross
+toolchain to your `PATH` and export the build variables:
 
 ```
-export PATH="$HOME/opt/cross/bin:$PATH"
+source envsetup.sh
 ```
 
 Then build the kernel:

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+export PREFIX="$HOME/opt/cross"
+export PATH="$PREFIX/bin:$PATH"
+export CC=x86_64-elf-gcc
+export AS=x86_64-elf-as
+export LD=x86_64-elf-ld
+export OBJCOPY=x86_64-elf-objcopy


### PR DESCRIPTION
## Summary
- provide `envsetup.sh` script for setting cross compiler variables
- instruct users to source the script in the README
- update Makefile to allow overriding toolchain variables

## Testing
- `make clean`
- `make` *(fails: `x86_64-elf-as` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b105d34483249cb6db3e7e8ca332