### PR TITLE
Use prewritten grub config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ kernel.bin: kernel.elf
 
 iso: kernel.bin
 	mkdir -p iso/boot/grub
-	echo 'set timeout=0' > iso/boot/grub/grub.cfg
-	echo 'set default=0' >> iso/boot/grub/grub.cfg
-	echo 'multiboot2 /boot/kernel.bin' >> iso/boot/grub/grub.cfg
+	cp grub/grub.cfg iso/boot/grub/
 	cp kernel.bin iso/boot/
 	grub-mkrescue -o kernel.iso iso >/dev/null 2>&1
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Then build the kernel:
 make
 ```
 
+The GRUB configuration used for the ISO lives in `grub/grub.cfg`.
 To create a bootable ISO image:
 
 ```

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,3 @@
+set timeout=0
+set default=0
+multiboot2 /boot/kernel.bin


### PR DESCRIPTION
## Summary
- add `grub/grub.cfg`
- copy that file in the `iso` target
- mention the GRUB config file in README

## Testing
- `make iso` *(fails: x86_64-elf-objcopy not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b1ab0b9883248bda12924e42c598