### PR TITLE
Add kernel.elf existence check in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ kernel.o: kernel.c
 
 kernel.elf: boot.o kernel_entry.o kernel.o linker.ld
 	$(LD) $(LDFLAGS) -o $@ boot.o kernel_entry.o kernel.o
+	@if [ -f $@ ]; then \
+		ls -l $@; \
+	else \
+		echo "Error: kernel.elf was not created. Check the link command and file paths."; \
+		exit 1; \
+	fi
 
 kernel.bin: kernel.elf
 	$(OBJCOPY) -O binary $< $@


### PR DESCRIPTION
## Summary
- add a post-link check for `kernel.elf` in the Makefile

## Testing
- `make clean`
- `make` *(fails: `x86_64-elf-objcopy` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b3fd3b7083248b7f5dadfc9e9796