### PR TITLE
Add cross-compile setup and README update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-CC=gcc
-AS=as
-LD=ld
-OBJCOPY=objcopy
+CC ?= x86_64-elf-gcc
+AS ?= x86_64-elf-as
+LD ?= x86_64-elf-ld
+OBJCOPY ?= x86_64-elf-objcopy
 CFLAGS=-ffreestanding -m64 -nostdlib -nostdinc -fno-pic -mno-red-zone -c
 ASFLAGS=--64
 LDFLAGS=-T linker.ld -nostdlib
@@ -23,18 +23,17 @@ kernel.elf: boot.o kernel_entry.o kernel.o linker.ld
 kernel.bin: kernel.elf
 	$(OBJCOPY) -O binary $< $@
 
-iso: kernel.bin
+iso: kernel.bin grub/grub.cfg
 	mkdir -p iso/boot/grub
-	echo 'set timeout=0' > iso/boot/grub/grub.cfg
-	echo 'set default=0' >> iso/boot/grub/grub.cfg
-	echo 'multiboot2 /boot/kernel.bin' >> iso/boot/grub/grub.cfg
 	cp kernel.bin iso/boot/
+	cp grub/grub.cfg iso/boot/grub/
 	grub-mkrescue -o kernel.iso iso >/dev/null 2>&1
 
 clean:
 	rm -rf *.o kernel.elf kernel.bin kernel.iso iso
 
 run: iso
-	qemu-system-x86_64 -cdrom kernel.iso -display none -serial mon:stdio
+	# Boot the ISO in QEMU with default graphical output
+	qemu-system-x86_64 -cdrom kernel.iso
 
 .PHONY: all iso clean run

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # vkernel
+
+This repository contains a minimal x86_64 hobby kernel.
+
+## Building
+
+First set up the cross‑compiler environment (the toolchain can be built with
+`build_toolchain.sh` and installs to `$HOME/opt/cross`):
+
+```bash
+source envsetup.sh
+```
+
+```
+make
+```
+
+To create a bootable ISO image (uses `grub/grub.cfg` for the boot menu):
+
+```
+make iso
+```
+
+## Running
+
+Run the kernel in QEMU:
+
+```
+make run
+```
+
+This opens a QEMU window so the VGA output from `kernel_main` is visible.

--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Set up environment variables for the cross compiler
+PREFIX="${HOME}/opt/cross"
+export PATH="${PREFIX}/bin:${PATH}"
+export CC="x86_64-elf-gcc"
+export AS="x86_64-elf-as"
+export LD="x86_64-elf-ld"
+export OBJCOPY="x86_64-elf-objcopy"

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=0
+set default=0
+
+menuentry "vkernel" {
+    multiboot2 /boot/kernel.bin
+    boot
+}

--- a/kernel_entry.s
+++ b/kernel_entry.s
@@ -1,4 +1,3 @@
-.intel_syntax noprefix
 .code64
 
 .global _start
@@ -10,15 +9,15 @@ kernel_entry:
 _start:
     cli
     # Load data segment selector (assume 0x10)
-    mov ax, 0x10
-    mov ds, ax
-    mov es, ax
-    mov fs, ax
-    mov gs, ax
-    mov ss, ax
+    movw $0x10, %ax
+    movw %ax, %ds
+    movw %ax, %es
+    movw %ax, %fs
+    movw %ax, %gs
+    movw %ax, %ss
 
     # Set up stack pointer
-    lea rsp, [stack_top]
+    leaq stack_top(%rip), %rsp
 
     call kernel_main
 


### PR DESCRIPTION
## Summary
- provide `envsetup.sh` for setting the cross‑compiler environment
- let the Makefile default to x86_64 cross tools via `?=`
- document sourcing `envsetup.sh` before building

## Testing
- `make clean`
- `make all` *(fails: x86_64-elf-objcopy not found)*
- `make iso` *(fails: x86_64-elf-objcopy not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426ad0c3a083249d71354be3dce9c4