### PR TITLE
Add boot directive to grub.cfg

### DIFF
--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,3 +1,4 @@
 set timeout=0
 set default=0
 multiboot2 /boot/kernel.bin
+boot


### PR DESCRIPTION
## Summary
- ensure the kernel boots by explicitly calling `boot`

## Testing
- `tail -n 5 grub/grub.cfg`


------
https://chatgpt.com/codex/tasks/task_e_6843b98a65848324b3b8d8829c3fcfde