### PR TITLE
Add loadable multiboot section

### DIFF
--- a/boot.s
+++ b/boot.s
@@ -1,6 +1,6 @@
 .code32
 
-.section .multiboot
+.section .multiboot,"a"
     .align 8
 multiboot_header:
     .long 0xE85250D6            # magic (multiboot2)

--- a/linker.ld
+++ b/linker.ld
@@ -2,6 +2,7 @@ ENTRY(start)
 SECTIONS
 {
     . = 1M;
+    .multiboot : { *(.multiboot) }
     .text : { *(.text) }
     .rodata : { *(.rodata*) }
     .data : { *(.data) }


### PR DESCRIPTION
## Summary
- mark the multiboot header as loadable in boot.s
- link `.multiboot` prior to `.text` in the linker script

## Testing
- `make iso`
- `make run` *(fails: gtk initialization failed)*

------
https://chatgpt.com/codex/tasks/task_e_6843bb5d9a5483249fa0f75395b5dc2c