### PR TITLE
Fix multiboot section attributes

### DIFF
--- a/boot.s
+++ b/boot.s
@@ -1,6 +1,6 @@
 .code32
 
-.section .multiboot,"a"
+.section .multiboot, "a", @progbits
     .align 8
 multiboot_header:
     .long 0xE85250D6            # magic (multiboot2)


### PR DESCRIPTION
## Summary
- mark `.multiboot` as a progbits section

## Testing
- `make clean`
- `make iso` *(fails: `grub-mkrescue` not found)*
- `readelf -l kernel.elf`

------
https://chatgpt.com/codex/tasks/task_e_6843bdda81508324a7cf80b71a55b18d