### PR TITLE
Update iso rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,11 @@ iso: kernel.bin
 	mkdir -p iso/boot/grub
 	cp grub/grub.cfg iso/boot/grub/
 	cp kernel.bin iso/boot/
-	grub-mkrescue -o kernel.iso iso >/dev/null 2>&1
+	if ! command -v grub-mkrescue >/dev/null; then \
+	echo "Error: grub-mkrescue not found. Please install GRUB to build the ISO."; \
+	exit 1; \
+	fi
+	grub-mkrescue -o kernel.iso iso
 
 clean:
 	rm -rf *.o kernel.elf kernel.bin kernel.iso iso


### PR DESCRIPTION
## Summary
- keep grub-mkrescue output visible
- stop Makefile with a helpful error if grub-mkrescue is missing

## Testing
- `make iso` *(fails: grub-mkrescue not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843be7c366483248e571ad8096e4f11