### PR TITLE
Disable CET to remove endbr64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC ?= x86_64-elf-gcc
 AS ?= x86_64-elf-as
 LD ?= x86_64-elf-ld
 OBJCOPY ?= objcopy
-CFLAGS=-ffreestanding -m64 -nostdlib -nostdinc -fno-pic -mno-red-zone -c
+CFLAGS=-ffreestanding -m64 -nostdlib -nostdinc -fno-pic -mno-red-zone -c -fcf-protection=none
 ASFLAGS=--64
 LDFLAGS=-T linker.ld -nostdlib
 


### PR DESCRIPTION
## Summary
- disable CET in the kernel build by adding `-fcf-protection=none`

## Testing
- `make CC=gcc AS=as LD=ld OBJCOPY=objcopy`
- `objdump -d kernel.elf | grep -n endbr64`

------
https://chatgpt.com/codex/tasks/task_e_6843bffa98808324acbaef777c8b800a